### PR TITLE
Add issues to a project based on milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This demo shows an issue that has the priority label added automatically get mov
 ![](demo.gif)
 
 ### Use Case
-Everytime a specific label is added to an issue, the associated card in a project should be moved to a specific column. For example, you want any issue that gets labeled with "priority" to automatically move to the column that corresponds to "on deck". If the issue is not on the project board, it will be created in the desired column. If it has already been added, it will be moved to the correct column.
+Everytime a specific label is added to an issue (or issue added to a milestone), the associated card in a project should be moved to a specific column. For example, you want any issue that gets labeled with "priority" to automatically move to the column that corresponds to "on deck". If the issue is not on the project board, it will be created in the desired column. If it has already been added, it will be moved to the correct column.
 
 This action can be used for projects that are linked and setup at the org level or repository level. The token that is supplied though must have `repo` permissions. If the project is linked at the org level, it must also have `org:read` permissions.
 
@@ -17,7 +17,8 @@ This action can be used for projects that are linked and setup at the org level 
 |  action-token | An access token that will be used to move or create an issue in a desired column. The standard token that is present for each action will not be sufficient as it does not have sufficient privilages. You must create one that has `repo` permissions (see below)  |
 | project-url  | The url of the project. Will be something like `https://github.com/orgs/github/projects/1` or `https://github.com/konradpabjan/example/projects/1`  |
 | column-name | The name of the column in projec that issues should be moved to |
-| label-name | The label that should trigger an issue to be moved to a specific column |
+| label-name | The label that should trigger an issue to be moved to a specific column (mutually exclusive with milestone-name) |
+| milestone-name | The milestone that should trigger an issue to be moved to a specific column (mutually exclusive with label-name) |
 | columns-to-ignore | Comma seperated list of column names that should be ignored. If an issue/card already exists in a column with one of the names, it will be ignored. This is optional|
 
 ### Creating an action-token
@@ -27,7 +28,7 @@ This action can be used for projects that are linked and setup at the org level 
 - Use the newly saved token in your YAML file as input for `action-token`. In the example below, it is called `MY_TOKEN`
 
 
-### Example YAML
+### Example YAML (label)
 
 This YAML is meant to be triggered whenever an issue has been labled.
 
@@ -45,5 +46,26 @@ jobs:
         project-url: "https://github.com/orgs/github/projects/1"
         column-name: "On Deck"
         label-name: "priority"
+        columns-to-ignore: "In Review,Ready to deploy,Done"
+ ```
+
+### Example YAML (milestone)
+
+This YAML is meant to be triggered whenever an issue has been milestoned.
+
+```
+on:
+  issues:
+    types: [milestoned]
+jobs:
+  Move_Milestoned_Issue_On_Project_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: konradpabjan/actions-move-labeled-issue-repo@v1.0
+      with:
+        action-token: "${{ secrets.MY_TOKEN }}"
+        project-url: "https://github.com/orgs/github/projects/1"
+        column-name: "On Deck"
+        milestone-name: "v1.0"
         columns-to-ignore: "In Review,Ready to deploy,Done"
  ```

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,11 @@ inputs:
     description: 'The column that the card should end up'
     required: true
   label-name:
-    description: 'The label that specifies if an issue should be automatically moved to the column'
-    required: true
+    description: 'The label that specifies if an issue should be automatically moved to the column (mutually exclusive with milestone-name)'
+    required: false
+  milestone-name:
+    description: 'The milestone that specifies if an issue should be automatically moved to the column (mutually exclusive with label-name)'
+    required: false
   columns-to-ignore:
     description: 'Comma seperated list of columns to ignore. If a card/issue is already in one of these columns, it will not be moved'
     required: false

--- a/index.js
+++ b/index.js
@@ -7,16 +7,31 @@ async function run() {
     const projectUrl = core.getInput("project-url");
     const columnName = core.getInput("column-name");
     const labelName = core.getInput("label-name");
+    const milestoneName = core.getInput("milestone-name");
     const ignoreList = core.getInput("columns-to-ignore");
     const octokit = new github.GitHub(myToken);
     const context = github.context;
 
+    if(!milestoneName && !labelName){
+        throw new Error("one of label-name and milestone-name must be set");
+    }
+    else if (milestoneName && labelName){
+        throw new Error("label-name and milestone-name cannot both be set");
+    }
+
     var found = false;
-    context.payload.issue.labels.forEach(function(item){
-        if(labelName == item.name){
+    if(labelName){
+        context.payload.issue.labels.forEach(function(item){
+            if(labelName == item.name){
+                found = true;
+            }
+        });
+    }
+    if(milestoneName){
+        if(context.payload.issue.milestone && context.payload.issue.milestone.title == milestoneName){
             found = true;
         }
-    });
+    }
 
     if(found){
         // get the columnId for the project where the issue should be added/moved


### PR DESCRIPTION
The action may now be triggered when an issue is either labeled or added
to a milestone. Use the 'milestone-name' input to define the milestone
title to match. label-name and milestone-name are mutually exclusive.

Example:

This YAML is meant to be triggered whenever an issue has been milestoned.

```
on:
  issues:
    types: [milestoned]
jobs:
  Move_Milestoned_Issue_On_Project_Board:
    runs-on: ubuntu-latest
    steps:
    - uses: konradpabjan/actions-move-labeled-issue-repo@v1.0
      with:
        action-token: "${{ secrets.MY_TOKEN }}"
        project-url: "https://github.com/orgs/github/projects/1"
        column-name: "On Deck"
        milestone-name: "v1.0"
        columns-to-ignore: "In Review,Ready to deploy,Done"
 ```