### PR TITLE
Allow all columns to be ignored if the card exists on the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action can be used for projects that are linked and setup at the org level 
 | project-url  | The url of the project. Will be something like `https://github.com/orgs/github/projects/1` or `https://github.com/konradpabjan/example/projects/1`  |
 | column-name | The name of the column in projec that issues should be moved to |
 | label-name | The label that should trigger an issue to be moved to a specific column |
-| columns-to-ignore | Comma seperated list of column names that should be ignored. If an issue/card already exists in a column with one of the names, it will be ignored. This is optional|
+| columns-to-ignore | Comma separated list of column names that should be ignored. If an issue/card already exists in a column with one of the names, it will be ignored. Use `*` to ignore all columns. This is optional|
 
 ### Creating an action-token
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'The label that specifies if an issue should be automatically moved to the column'
     required: true
   columns-to-ignore:
-    description: 'Comma seperated list of columns to ignore. If a card/issue is already in one of these columns, it will not be moved'
+    description: 'Comma separated list of columns to ignore. If a card/issue is already in one of these columns, it will not be moved. Use `*` to ignore all columns'
     required: false
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function run() {
         console.log(`columnId is: ${columnId}, cardId is: ${cardId}, currentColumn is: ${currentColumn}`);
 
         var skip = ignoreList.split(",");
-        if (cardId != null && skip.includes(currentColumn)){
+        if (cardId != null && (ignoreList == "*" || skip.includes(currentColumn))){
             // card is present in a column that we want to ignore, don't move or do anything
             return `Card exists for issue in column ${currentColumn}. Column specified to be ignored, not moving issue.`;
         }


### PR DESCRIPTION
This allows a new issue to always be added to the board, but will never
move an issue that is already on the board.