### PR TITLE
Add the ability to create notes instead of cards

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Dogfood
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Labeled_Issue_On_Project_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.1
+      with:
+        action-token: "${{ secrets.MY_TOKEN }}"
+        project-url: "https://github.com/aareet/add-note-to-project-action/projects/1"
+        column-name: "Needs triage"
+        label-name: "test"
+        add-as-note: true 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   columns-to-ignore:
     description: 'Comma separated list of columns to ignore. If a card/issue is already in one of these columns, it will not be moved. Use `*` to ignore all columns'
     required: false
+  add-as-note:
+    description: 'Set this to true if you want to add the issue in a note instead of adding the card to the project.'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
If an issue belongs to Organization #1, you cannot add that issue as a card to a project in Organization #2. However, if you add the issue URL as a note instead, the issue can successfully be embedded in the appropriate column of Organization #2. This PR allows you to set a flag to create notes instead of cards if that is your preference based on your project location and setup.